### PR TITLE
Remove hard-coded directory separator

### DIFF
--- a/Interpretation Engine/Constants.cs
+++ b/Interpretation Engine/Constants.cs
@@ -16,7 +16,7 @@ namespace AMR_Engine
 
 		// We use this to locate resources.
 		public static string SystemRootPath = 
-			Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location) + "\\";
+			Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location) + System.IO.Path.DirectorySeparatorChar;
 
 		public class Disk
 		{


### PR DESCRIPTION
Use `System.IO.Path.DirectorySeparatorChar` instead of the hard-coded `"\\"` which does not work on Mac or Linux.