### PR TITLE
Use `Path.Join` to concatenate file paths.

### DIFF
--- a/Interpretation Engine/Antibiotic.cs
+++ b/Interpretation Engine/Antibiotic.cs
@@ -307,11 +307,11 @@ namespace AMR_Engine
 		private static List<Antibiotic> LoadAntibiotics()
 		{
 			string antibioticsTableFile;
-			const string relativePath = "Resources\\Antibiotics.txt";
+			string relativePath = Path.Join("Resources", "Antibiotics.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				antibioticsTableFile = relativePath;
 			else
-				antibioticsTableFile = Constants.SystemRootPath + relativePath;
+				antibioticsTableFile = Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (File.Exists(antibioticsTableFile))
 			{

--- a/Interpretation Engine/Breakpoint.cs
+++ b/Interpretation Engine/Breakpoint.cs
@@ -89,7 +89,7 @@ namespace AMR_Engine
 		/// List of breakpoints loaded from the text file resource.
 		/// </summary>
 		public static readonly List<Breakpoint> Breakpoints = 
-			LoadBreakpoints(string.Format("{0}{1}", Constants.SystemRootPath, "Resources\\Breakpoints.txt"));
+			LoadBreakpoints(Path.Join(Constants.SystemRootPath, "Resources", "Breakpoints.txt"));
 
 		#endregion
 

--- a/Interpretation Engine/ExpectedResistancePhenotypeRule.cs
+++ b/Interpretation Engine/ExpectedResistancePhenotypeRule.cs
@@ -265,11 +265,11 @@ namespace AMR_Engine
 		private static List<ExpectedResistancePhenotypeRule> LoadExpectedResistancePhenotypeRules()
 		{
 			string expectedResistancePhenotypesTableFile;
-			const string relativePath = "Resources\\ExpectedResistancePhenotypes.txt";
+			string relativePath = Path.Join("Resources", "ExpectedResistancePhenotypes.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				expectedResistancePhenotypesTableFile = relativePath;
 			else
-				expectedResistancePhenotypesTableFile = Constants.SystemRootPath + relativePath;
+				expectedResistancePhenotypesTableFile = Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (File.Exists(expectedResistancePhenotypesTableFile))
 			{

--- a/Interpretation Engine/ExpertInterpretationRule.cs
+++ b/Interpretation Engine/ExpertInterpretationRule.cs
@@ -279,11 +279,11 @@ namespace AMR_Engine
 		private static List<ExpertInterpretationRule> LoadExpertInterpretationRules()
 		{
 			string expertRulesTableFile;
-			const string relativePath = "Resources\\ExpertInterpretationRules.txt";
+			string relativePath = Path.Join("Resources", "ExpertInterpretationRules.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				expertRulesTableFile = relativePath;
 			else
-				expertRulesTableFile = Constants.SystemRootPath + relativePath;
+				expertRulesTableFile = Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (File.Exists(expertRulesTableFile))
 			{

--- a/Interpretation Engine/Organism.cs
+++ b/Interpretation Engine/Organism.cs
@@ -126,11 +126,11 @@ namespace AMR_Engine
 		private static Dictionary<string, Organism> LoadCurrentOrganisms()
 		{
 			string organismsTableFile;
-			const string relativePath = "Resources\\Organisms.txt";
+			string relativePath = System.IO.Path.Join("Resources", "Organisms.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				organismsTableFile = relativePath;
 			else
-				organismsTableFile = Constants.SystemRootPath + relativePath;
+				organismsTableFile = System.IO.Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (File.Exists(organismsTableFile))
 			{
@@ -193,11 +193,11 @@ namespace AMR_Engine
 		private static Dictionary<string, string> LoadMergedOrganisms()
 		{
 			string organismsTableFile;
-			const string relativePath = "Resources\\Organisms.txt";
+			string relativePath = Path.Join("Resources", "Organisms.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				organismsTableFile = relativePath;
 			else
-				organismsTableFile = Constants.SystemRootPath + relativePath;
+				organismsTableFile = Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (File.Exists(organismsTableFile))
 			{

--- a/Interpretation Engine/QualityControlRange.cs
+++ b/Interpretation Engine/QualityControlRange.cs
@@ -177,11 +177,11 @@ namespace AMR_Engine
 		private static List<QualityControlRange> LoadQualityControlRanges()
 		{
 			string qualityControlTableFile;
-			const string relativePath = "Resources\\QC_Ranges.txt";
+			string relativePath = Path.Join("Resources", "QC_Ranges.txt");
 			if (string.IsNullOrWhiteSpace(Constants.SystemRootPath))
 				qualityControlTableFile = relativePath;
 			else
-				qualityControlTableFile = Constants.SystemRootPath + relativePath;
+				qualityControlTableFile = Path.Join(Constants.SystemRootPath, relativePath);
 
 			if (!string.IsNullOrWhiteSpace(qualityControlTableFile) && File.Exists(qualityControlTableFile))
 			{


### PR DESCRIPTION
The `\` char in resource paths such as `Resources\\Antibiotics.txt` does not work on Mac/Linux. One can use the built-in `Path.Join` method to concatenates paths into a single path.