### PR TITLE
Switch to WinGet Releaser (GitHub Action)

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -1,27 +1,14 @@
-name: Submit WHONET.AMRIE package to Windows Package Manager Community Repository
-
+name: Publish to WinGet
 on:
-  workflow_dispatch:
   release:
-    types: [published]
-
+    types: [released]
 jobs:
-  winget:
-    name: Publish winget package
+  publish:
     runs-on: windows-latest
     steps:
-      - name: Submit package to Windows Package Manager Community Repository
-        run: |
-
-          $wingetPackage = "WHONET.AMRIE"
-          $gitToken = "${{ secrets.WINGET_TOKEN }}"
-
-          $github = Invoke-RestMethod -uri "https://api.github.com/repos/AClark-WHONET/AMRIE/releases" 
-
-          $targetRelease = $github | Where-Object -Property name -match 'Release'| Select -First 1
-          $installerUrl = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'AMR_Interpretation_Engine.msi' | Select -ExpandProperty browser_download_url
-          $ver = $targetRelease.tag_name.Trim("v")
-
-          # getting latest wingetcreate file
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update $wingetPackage -s -v $ver -u "$installerUrl|x86" "$installerUrl|x64" -t $gitToken
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: WHONET.AMRIE
+          installers-regex: '\.msi$' # Only .msi files
+          max-versions-to-keep: 1 # keep only latest 1 version
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -9,6 +9,4 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: WHONET.AMRIE
-          installers-regex: '\.msi$' # Only .msi files
-          max-versions-to-keep: 1 # keep only latest 1 version
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
https://github.com/vedantmgoyal2009/winget-releaser

1. You will need to create a classic Personal Access Token (PAT) with public_repo scope. New fine-grained PATs aren't supported by the action. Review https://github.com/vedantmgoyal2009/winget-releaser/issues/172 for information.

2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking [winget-pkgs](https://github.com/microsoft/winget-pkgs) on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.
 
3. Ensure that the fork is up-to-date with the upstream. You can use [ Pull App](https://github.com/wei/pull) which keeps your fork up-to-date via automated pull requests.
 
4. Add the action to your workflow file (e.g. .github/workflows/<name>.yml).