### PR TITLE
Format version correctly by stripping 'v' from version tag

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -10,14 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+
+      - name: Extract version without 'v'
+        id: format_version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # ${TAG#v} strips the 'v' from the beginning of the string
+          echo "CLEAN_VERSION=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Run Komac
         uses: michidk/run-komac@v2
         with:
           args: >
             update WHONET.AMRIE 
-            --version ${{ github.event.release.tag_name }} 
+            --version ${{ steps.format_version.outputs.CLEAN_VERSION }} 
             --urls "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/AMR_Interpretation_Engine_${{ github.event.release.tag_name }}.msi" 
             --submit 
             --token ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Looking at latest submitted PR (https://github.com/microsoft/winget-pkgs/pull/352581), I see that version is parsed with "v" prefix which is not ideal.

I have added code to strip 'v' from version tag.
                OR

Alternative would be to use `winget-releaser` action which does this automatically.

```
name: Submit WHONET.AMRIE package to Windows Package Manager Community Repository

on:
  release:
    types: [released]

jobs:
  publish-winget:
    name: Publish winget package
    runs-on: ubuntu-latest
    steps:
      - name: Submit to WinGet
        uses: vedantmgoyal9/winget-releaser@v2
        with:
          identifier: WHONET.AMRIE
          installers-regex: '\.msi$' 
          token: ${{ secrets.WINGET_TOKEN }}
```
