### PR TITLE
ci: update GitHub Actions workflow to use checkout@v7

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   komac:
     name: Publish winget package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract version without 'v'
         id: format_version


### PR DESCRIPTION
## 📌 Summary
Updates the WinGet publication workflow (`komac`) to use the latest version of the `actions/checkout` action and switches the runner to `ubuntu-slim`.

## 🔄 Changes
* **Action Update:** Upgraded `actions/checkout` to `@v7`.
* **Runner Update:** Changed `runs-on` from `ubuntu-latest` to `ubuntu-slim` for faster, lightweight job execution.

## ✅ Verification
- [x] Verified workflow syntax and YAML formatting.